### PR TITLE
Take consent from user before redirecting to payment.

### DIFF
--- a/src/app/events/[eventId]/page.js
+++ b/src/app/events/[eventId]/page.js
@@ -374,7 +374,7 @@ const Event = () => {
     e.preventDefault();
     console.log(Team, Emails, memberRoles);
     if (allValid) {
-      await getPayUForm();
+      confirm("Are you ready to make the payment? (You'll be redirected to the payment gateway to complete the registration.)") && await getPayUForm();
     }
   };
 
@@ -442,7 +442,7 @@ const Event = () => {
                     ? setpopupvisibility(true)
                     : eventData.isRegistered != undefined &&
                       eventData.isRegistered == "0"
-                    ? getPayUForm()
+                    ? confirm("Are you ready to make the payment? (You'll be redirected to the payment gateway to complete the registration.)") && getPayUForm()
                     : setpopupvisibility(true);
                 }}
                 disabled={false}


### PR DESCRIPTION
In an attempt to reduce the number of transactions that fail or end up as pending, added a flow where only after accepting that the user is ready to make the payment, we redirect them to the payment gateway.

- [x] Confirm with user before redirecting to payU.
    - [x] individual event registration.
    - [x] group event registration.

 